### PR TITLE
Fix handling of missing headers in the b3 codec (#215)

### DIFF
--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -339,6 +339,20 @@ class TestCodecs(unittest.TestCase):
         span_context = codec.extract(carrier)
         assert span_context.flags == 0x01
 
+        # validate present debug header with falsy value
+        carrier = {'X-b3-SpanId': 'a2fb4a1d1a96d312', 'X-B3-flags': '0',
+                   'X-B3-traceId': '463ac35c9f6413ad48485a3953bb6124'}
+        span_context = codec.extract(carrier)
+        assert span_context.flags == 0x00
+
+        # validate missing context
+        assert codec.extract({}) is None
+
+        # validate explicit none in context
+        carrier = {'X-b3-SpanId': None,
+                   'X-B3-traceId': '463ac35c9f6413ad48485a3953bb6124'}
+        assert codec.extract(carrier) is None
+
         # validate invalid hex string
         with self.assertRaises(SpanContextCorruptedException):
             codec.extract({'x-B3-TraceId': 'a2fb4a1d1a96d312z'})


### PR DESCRIPTION
* Fix handling of missing headers in the b3 codec

The b3 codec uses .get() to extract headers and so does not throw a key
error if headers are missing.  However many of these headers are decoded
via "header_to_hex" which throws an exception on a None value.  Other
codecs handle the missing header case by returning None, update the b3
codec to follow this convention.

Signed-off-by: Caleb Howe <Caleb.S.Howe@gmail.com>